### PR TITLE
Fix gdbserver widget keyhander callback pointer

### DIFF
--- a/ui/widget/widget.c
+++ b/ui/widget/widget.c
@@ -694,7 +694,7 @@ widget_t widget_data[] = {
   { widget_query_save_draw,widget_query_finish,	 widget_query_save_keyhandler },
   { widget_diskoptions_draw, widget_options_finish, widget_diskoptions_keyhandler  },
   { widget_binary_draw, widget_binary_finish, widget_binary_keyhandler  },
-  { widget_gdbserver_draw,  widget_options_finish, widget_general_keyhandler  },
+  { widget_gdbserver_draw,  widget_options_finish, widget_gdbserver_keyhandler  },
 };
 
 #ifndef UI_SDL


### PR DESCRIPTION
Fix a typo and use widget_gdbserver_keyhandler callback instead of widget_general_keyhandler for the gdbserver widget.
Otherwise, the gdbserver menu is unsable with the SDL UI.